### PR TITLE
Fixes #58 Garbage collection fix on bitmap handles and performance improvements

### DIFF
--- a/SpellGUIV2/MainWindow.xaml
+++ b/SpellGUIV2/MainWindow.xaml
@@ -42,7 +42,11 @@
                     <c:ThreadSafeTextBox x:Name="FilterSpellNames" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="292.873,83,0,0" Width="200" TextWrapping="NoWrap" KeyDown="_KeyDown" KeyUp="_KeyUp" Grid.Column="1"/>
 
                     <Label Name="SpellsLoadedLabel" Content="{DynamicResource labSpellsLoaded}" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="192.873,9,0,0" Grid.Column="1"/>
-                    <ListBox Name="SelectSpell" VerticalAlignment="Top" HorizontalAlignment="Left" Height="642" Width="443" SelectionChanged="SelectSpell_SelectionChanged" Focusable="False" Grid.ColumnSpan="2"/>
+                    <ListBox Name="SelectSpell"
+                             VirtualizingStackPanel.IsVirtualizing="True"
+                             VirtualizingStackPanel.VirtualizationMode="Recycling"
+                             ScrollViewer.IsDeferredScrollingEnabled="True"
+                             VerticalAlignment="Top" HorizontalAlignment="Left" Height="642" Width="443" SelectionChanged="SelectSpell_SelectionChanged" Focusable="False" Grid.ColumnSpan="2"/>
                     <TabControl VerticalAlignment="Top" HorizontalAlignment="Left" Margin="193,114,0,0" Height="546" Width="822" Grid.Column="1">
                         <TabItem x:Name="TabItem_English" Header="{DynamicResource tabEnglish}">
                             <Grid>

--- a/SpellGUIV2/Sources/DBC/SpellIconDBC.cs
+++ b/SpellGUIV2/Sources/DBC/SpellIconDBC.cs
@@ -108,11 +108,18 @@ namespace SpellEditor.Sources.DBC
                         temp.Margin = iconMargin == null ? new Thickness(margin, 0, 0, 0) : iconMargin.Value;
                         temp.VerticalAlignment = VerticalAlignment.Top;
                         temp.HorizontalAlignment = HorizontalAlignment.Left;
-                        temp.Source = System.Windows.Interop.Imaging.CreateBitmapSourceFromHBitmap(
-                            bit.GetHbitmap(), IntPtr.Zero, Int32Rect.Empty, 
-                            BitmapSizeOptions.FromWidthAndHeight(bit.Width, bit.Height));
+                        var handle = bit.GetHbitmap();
+                        try
+                        {
+                            temp.Source = System.Windows.Interop.Imaging.CreateBitmapSourceFromHBitmap(
+                                handle, IntPtr.Zero, Int32Rect.Empty,
+                                BitmapSizeOptions.FromWidthAndHeight(bit.Width, bit.Height));
+                        }
+                        finally
+                        {
+                            MainWindow.DeleteObject(handle);
+                        }
                         temp.Name = "CurrentSpellIcon";
-
                         // Code smells here on hacky positioning and updating the icon
                         temp.Margin = new Thickness(103, 38, 0, 0);
                         main.CurrentIconGrid.Children.Clear();
@@ -170,11 +177,19 @@ namespace SpellEditor.Sources.DBC
                 temp.Margin = iconMargin == null ? new Thickness(margin, 0, 0, 0) : iconMargin.Value;
                 temp.VerticalAlignment = VerticalAlignment.Top;
                 temp.HorizontalAlignment = HorizontalAlignment.Left;
-                temp.Source = System.Windows.Interop.Imaging.CreateBitmapSourceFromHBitmap(bit.GetHbitmap(), IntPtr.Zero, Int32Rect.Empty, BitmapSizeOptions.FromWidthAndHeight(bit.Width, bit.Height));
+                var handle = bit.GetHbitmap();
+                try
+                {
+                    temp.Source = System.Windows.Interop.Imaging.CreateBitmapSourceFromHBitmap(
+                        handle, IntPtr.Zero, Int32Rect.Empty, BitmapSizeOptions.FromWidthAndHeight(bit.Width, bit.Height));
+                }
+                finally
+                {
+                    MainWindow.DeleteObject(handle);
+                }
                 temp.Name = "Index_" + entry.Offset;
                 temp.ToolTip = path;
                 temp.MouseDown += ImageDown;
-
                 main.IconGrid.Children.Add(temp);
                 bit.Dispose();
             }


### PR DESCRIPTION
Fixes bitmap handles not being garbage collected by manually calling the external function `DeleteObject`. Performance improvements have also been made on the Spell Selection List by enable Virtualizing Recycling mode.