### PR TITLE
Add a Spell Class Mask target list for each effect

### DIFF
--- a/Documentation/Languages/enUS.xaml
+++ b/Documentation/Languages/enUS.xaml
@@ -121,6 +121,7 @@
     <system:String x:Key="labEffectBonusMultiplier2">EffectBonusMultiplier 2:</system:String>
     <system:String x:Key="labDamageMultiplier3">Damage Multiplier 3:</system:String>
     <system:String x:Key="labEffectBonusMultiplier3">EffectBonusMultiplier 3:</system:String>
+	<system:String x:Key="targetClassMaskSpells">Class Mask Target Spells:</system:String>
     <system:String x:Key="labItemTool1">Totem 1:</system:String>
     <system:String x:Key="labItemTool2">Totem 2:</system:String>
     <system:String x:Key="labReagent1">Reagent 1:</system:String>

--- a/Documentation/Languages/enUS.xaml
+++ b/Documentation/Languages/enUS.xaml
@@ -121,7 +121,8 @@
     <system:String x:Key="labEffectBonusMultiplier2">EffectBonusMultiplier 2:</system:String>
     <system:String x:Key="labDamageMultiplier3">Damage Multiplier 3:</system:String>
     <system:String x:Key="labEffectBonusMultiplier3">EffectBonusMultiplier 3:</system:String>
-	<system:String x:Key="targetClassMaskSpells">Class Mask Target Spells:</system:String>
+    <system:String x:Key="targetClassMaskSpells">Class Mask Target Spells:</system:String>
+    <system:String x:Key="filterClassMaskSpells">Filter Target Spells:</system:String>
     <system:String x:Key="labItemTool1">Totem 1:</system:String>
     <system:String x:Key="labItemTool2">Totem 2:</system:String>
     <system:String x:Key="labReagent1">Reagent 1:</system:String>

--- a/Documentation/Languages/frFR.xaml
+++ b/Documentation/Languages/frFR.xaml
@@ -121,6 +121,7 @@
     <system:String x:Key="labEffectBonusMultiplier2">Multiplicateur de l'effet 2 :</system:String>
     <system:String x:Key="labDamageMultiplier3">Multiplicateur de dégâts 3 :</system:String>
     <system:String x:Key="labEffectBonusMultiplier3">Multiplicateur de l'effet 3 :</system:String>
+	<system:String x:Key="targetClassMaskSpells">Class Mask Target Spells:</system:String>
     <system:String x:Key="labItemTool1">Totem 1 :</system:String>
     <system:String x:Key="labItemTool2">Totem 2 :</system:String>
     <system:String x:Key="labReagent1">Réactif 1 :</system:String>

--- a/Documentation/Languages/frFR.xaml
+++ b/Documentation/Languages/frFR.xaml
@@ -121,7 +121,8 @@
     <system:String x:Key="labEffectBonusMultiplier2">Multiplicateur de l'effet 2 :</system:String>
     <system:String x:Key="labDamageMultiplier3">Multiplicateur de dégâts 3 :</system:String>
     <system:String x:Key="labEffectBonusMultiplier3">Multiplicateur de l'effet 3 :</system:String>
-	<system:String x:Key="targetClassMaskSpells">Class Mask Target Spells:</system:String>
+    <system:String x:Key="targetClassMaskSpells">Class Mask Target Spells:</system:String>
+    <system:String x:Key="filterClassMaskSpells">Filter Target Spells:</system:String>
     <system:String x:Key="labItemTool1">Totem 1 :</system:String>
     <system:String x:Key="labItemTool2">Totem 2 :</system:String>
     <system:String x:Key="labReagent1">Réactif 1 :</system:String>

--- a/Documentation/Languages/zhCN.xaml
+++ b/Documentation/Languages/zhCN.xaml
@@ -121,7 +121,8 @@
     <system:String x:Key="labEffectBonusMultiplier2" xml:space="preserve">        效果奖励乘数(?):</system:String>
     <system:String x:Key="labDamageMultiplier3" xml:space="preserve">              伤害乘数:</system:String>
     <system:String x:Key="labEffectBonusMultiplier3" xml:space="preserve">        效果奖励乘数(?):</system:String>
-	<system:String x:Key="targetClassMaskSpells">Class Mask Target Spells:</system:String>
+    <system:String x:Key="targetClassMaskSpells">Class Mask Target Spells:</system:String>
+    <system:String x:Key="filterClassMaskSpells">Filter Target Spells:</system:String>
     <system:String x:Key="labItemTool1">Totem 1:</system:String>
     <system:String x:Key="labItemTool2">Totem 2:</system:String>
     <system:String x:Key="labReagent1">消耗物品 1:</system:String>

--- a/Documentation/Languages/zhCN.xaml
+++ b/Documentation/Languages/zhCN.xaml
@@ -121,6 +121,7 @@
     <system:String x:Key="labEffectBonusMultiplier2" xml:space="preserve">        效果奖励乘数(?):</system:String>
     <system:String x:Key="labDamageMultiplier3" xml:space="preserve">              伤害乘数:</system:String>
     <system:String x:Key="labEffectBonusMultiplier3" xml:space="preserve">        效果奖励乘数(?):</system:String>
+	<system:String x:Key="targetClassMaskSpells">Class Mask Target Spells:</system:String>
     <system:String x:Key="labItemTool1">Totem 1:</system:String>
     <system:String x:Key="labItemTool2">Totem 2:</system:String>
     <system:String x:Key="labReagent1">消耗物品 1:</system:String>

--- a/SpellGUIV2/MainWindow.xaml
+++ b/SpellGUIV2/MainWindow.xaml
@@ -532,8 +532,10 @@
                                         <c:ThreadSafeTextBox x:Name="EffectDamageMultiplier1" VerticalAlignment="Top" HorizontalAlignment="Left" Height="23" Margin="610,259,0,0" Width="300" TextWrapping="Wrap"/>
                                         <Label Content="{DynamicResource labEffectBonusMultiplier1}" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="471,290,0,0"/>
                                         <c:ThreadSafeTextBox x:Name="EffectBonusMultiplier1" VerticalAlignment="Top" HorizontalAlignment="Left" Height="23" Margin="610,290,0,0" Width="300" TextWrapping="Wrap"/>
-                                        <Label Content="{DynamicResource targetClassMaskSpells}" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="929,42,0,0" RenderTransformOrigin="0.6,3.9"/>
-                                        <ListBox x:Name="EffectTargetSpellsList1" VerticalAlignment="Top" HorizontalAlignment="Left" Height="469" Margin="929,73,0,0" Width="300" BorderThickness="1"/>
+                                        <Label Content="{DynamicResource targetClassMaskSpells}" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="929,72,0,0" RenderTransformOrigin="0.6,3.9"/>
+                                        <ListBox x:Name="EffectTargetSpellsList1" VerticalAlignment="Top" HorizontalAlignment="Left" Height="436" Margin="929,103,0,0" Width="300" BorderThickness="1"/>
+                                        <Label Content="{DynamicResource filterClassMaskSpells}" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="929,45,0,0" RenderTransformOrigin="0.6,3.9"/>
+                                        <c:ThreadSafeTextBox x:Name="FilterClassMaskSpells1" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="1076,45,0,0" Width="153" TextWrapping="Wrap" TextChanged="FilterClassMaskSpells_TextChanged"/>
                                     </Grid>
                                 </TabItem>
                                 <TabItem Header="{DynamicResource SpellEffects2}">
@@ -582,8 +584,10 @@
                                         <c:ThreadSafeTextBox x:Name="EffectDamageMultiplier2" VerticalAlignment="Top" HorizontalAlignment="Left" Height="23" Margin="610,259,0,0" Width="300" TextWrapping="Wrap"/>
                                         <Label Content="{DynamicResource labEffectBonusMultiplier2}" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="471,290,0,0"/>
                                         <c:ThreadSafeTextBox x:Name="EffectBonusMultiplier2" VerticalAlignment="Top" HorizontalAlignment="Left" Height="23" Margin="610,290,0,0" Width="300" TextWrapping="Wrap"/>
-                                        <Label Content="{DynamicResource targetClassMaskSpells}" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="929,42,0,0" RenderTransformOrigin="0.6,3.9"/>
-                                        <ListBox x:Name="EffectTargetSpellsList2" VerticalAlignment="Top" HorizontalAlignment="Left" Height="469" Margin="929,73,0,0" Width="300" BorderThickness="1"/>
+                                        <Label Content="{DynamicResource targetClassMaskSpells}" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="929,72,0,0" RenderTransformOrigin="0.6,3.9"/>
+                                        <ListBox x:Name="EffectTargetSpellsList2" VerticalAlignment="Top" HorizontalAlignment="Left" Height="436" Margin="929,103,0,0" Width="300" BorderThickness="1"/>
+                                        <Label Content="{DynamicResource filterClassMaskSpells}" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="929,45,0,0" RenderTransformOrigin="0.6,3.9"/>
+                                        <c:ThreadSafeTextBox x:Name="FilterClassMaskSpells2" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="1076,45,0,0" Width="153" TextWrapping="Wrap" TextChanged="FilterClassMaskSpells_TextChanged"/>
                                     </Grid>
                                 </TabItem>
                                 <TabItem Header="{DynamicResource SpellEffects3}">
@@ -632,8 +636,10 @@
                                         <c:ThreadSafeTextBox x:Name="EffectDamageMultiplier3" VerticalAlignment="Top" HorizontalAlignment="Left" Height="23" Margin="610,259,0,0" Width="300" TextWrapping="Wrap"/>
                                         <Label Content="{DynamicResource labEffectBonusMultiplier2}" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="471,290,0,0"/>
                                         <c:ThreadSafeTextBox x:Name="EffectBonusMultiplier3" VerticalAlignment="Top" HorizontalAlignment="Left" Height="23" Margin="610,290,0,0" Width="300" TextWrapping="Wrap"/>
-                                        <Label Content="{DynamicResource targetClassMaskSpells}" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="929,42,0,0" RenderTransformOrigin="0.6,3.9"/>
-                                        <ListBox x:Name="EffectTargetSpellsList3" VerticalAlignment="Top" HorizontalAlignment="Left" Height="469" Margin="929,73,0,0" Width="300" BorderThickness="1"/>
+                                        <Label Content="{DynamicResource targetClassMaskSpells}" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="929,72,0,0" RenderTransformOrigin="0.6,3.9"/>
+                                        <ListBox x:Name="EffectTargetSpellsList3" VerticalAlignment="Top" HorizontalAlignment="Left" Height="436" Margin="929,103,0,0" Width="300" BorderThickness="1"/>
+                                        <Label Content="{DynamicResource filterClassMaskSpells}" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="929,45,0,0" RenderTransformOrigin="0.6,3.9"/>
+                                        <c:ThreadSafeTextBox x:Name="FilterClassMaskSpells3" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="1076,45,0,0" Width="153" TextWrapping="Wrap" TextChanged="FilterClassMaskSpells_TextChanged"/>
                                     </Grid>
                                 </TabItem>
                             </TabControl>

--- a/SpellGUIV2/MainWindow.xaml
+++ b/SpellGUIV2/MainWindow.xaml
@@ -485,7 +485,7 @@
                     </TabItem>
                     <TabItem Header="{DynamicResource Effects2}">
                         <Grid>
-                            <TabControl VerticalAlignment="Top" HorizontalAlignment="Left" Height="606" Width="1276">
+                            <TabControl VerticalAlignment="Top" HorizontalAlignment="Left" Height="647" Width="1276">
                                 <TabItem Header="{DynamicResource SpellEffects1}">
                                     <Grid>
                                         <Label Content="{DynamicResource labSpellEffect}" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="20,41,0,0"/>
@@ -523,15 +523,17 @@
                                         <Label Content="{DynamicResource labMiscValueB}" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="471,135,0,0"/>
                                         <c:ThreadSafeTextBox x:Name="MiscValueB1" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="610,135,0,0" Width="300" TextWrapping="Wrap"/>
                                         <Label Content="{DynamicResource labSpellClassMask1}" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="471,166,0,0"/>
-                                        <c:ThreadSafeComboBox x:Name="SpellMask11" VerticalAlignment="Top" HorizontalAlignment="Left" Height="23" Margin="610,166,0,0" Width="300" IsEditable="True" IsReadOnly="True"/>
+                                        <c:ThreadSafeComboBox x:Name="SpellMask11" VerticalAlignment="Top" HorizontalAlignment="Left" Height="23" Margin="610,166,0,0" Width="300" IsEditable="True" IsReadOnly="True" SelectionChanged="SpellMask_SelectionChanged"/>
                                         <Label Content="{DynamicResource labSpellClassMask2}" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="471,197,0,0"/>
-                                        <c:ThreadSafeComboBox x:Name="SpellMask21" VerticalAlignment="Top" HorizontalAlignment="Left" Height="23" Margin="610,197,0,0" Width="300" IsEditable="True" IsReadOnly="True" />
+                                        <c:ThreadSafeComboBox x:Name="SpellMask21" VerticalAlignment="Top" HorizontalAlignment="Left" Height="23" Margin="610,197,0,0" Width="300" IsEditable="True" IsReadOnly="True" SelectionChanged="SpellMask_SelectionChanged"/>
                                         <Label Content="{DynamicResource labSpellClassMask3}" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="471,228,0,0"/>
-                                        <c:ThreadSafeComboBox x:Name="SpellMask31" VerticalAlignment="Top" HorizontalAlignment="Left" Height="23" Margin="610,228,0,0" Width="300" IsEditable="True" IsReadOnly="True" />
+                                        <c:ThreadSafeComboBox x:Name="SpellMask31" VerticalAlignment="Top" HorizontalAlignment="Left" Height="23" Margin="610,228,0,0" Width="300" IsEditable="True" IsReadOnly="True" SelectionChanged="SpellMask_SelectionChanged"/>
                                         <Label Content="{DynamicResource labDamageMultiplier1}" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="471,259,0,0"/>
                                         <c:ThreadSafeTextBox x:Name="EffectDamageMultiplier1" VerticalAlignment="Top" HorizontalAlignment="Left" Height="23" Margin="610,259,0,0" Width="300" TextWrapping="Wrap"/>
                                         <Label Content="{DynamicResource labEffectBonusMultiplier1}" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="471,290,0,0"/>
                                         <c:ThreadSafeTextBox x:Name="EffectBonusMultiplier1" VerticalAlignment="Top" HorizontalAlignment="Left" Height="23" Margin="610,290,0,0" Width="300" TextWrapping="Wrap"/>
+                                        <Label Content="{DynamicResource targetClassMaskSpells}" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="929,42,0,0" RenderTransformOrigin="0.6,3.9"/>
+                                        <ListBox x:Name="EffectTargetSpellsList1" VerticalAlignment="Top" HorizontalAlignment="Left" Height="469" Margin="929,73,0,0" Width="300" BorderThickness="1"/>
                                     </Grid>
                                 </TabItem>
                                 <TabItem Header="{DynamicResource SpellEffects2}">
@@ -571,15 +573,17 @@
                                         <Label Content="{DynamicResource labMiscValueB}" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="471,135,0,0"/>
                                         <c:ThreadSafeTextBox x:Name="MiscValueB2" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="610,135,0,0" Width="300" TextWrapping="Wrap"/>
                                         <Label Content="{DynamicResource labSpellClassMask1}" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="471,166,0,0"/>
-                                        <c:ThreadSafeComboBox x:Name="SpellMask12" VerticalAlignment="Top" HorizontalAlignment="Left" Height="23" Margin="610,166,0,0" Width="300" IsEditable="True" IsReadOnly="True" />
+                                        <c:ThreadSafeComboBox x:Name="SpellMask12" VerticalAlignment="Top" HorizontalAlignment="Left" Height="23" Margin="610,166,0,0" Width="300" IsEditable="True" IsReadOnly="True" SelectionChanged="SpellMask_SelectionChanged"/>
                                         <Label Content="{DynamicResource labSpellClassMask2}" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="471,197,0,0"/>
-                                        <c:ThreadSafeComboBox x:Name="SpellMask22" VerticalAlignment="Top" HorizontalAlignment="Left" Height="23" Margin="610,197,0,0" Width="300" IsEditable="True" IsReadOnly="True" />
+                                        <c:ThreadSafeComboBox x:Name="SpellMask22" VerticalAlignment="Top" HorizontalAlignment="Left" Height="23" Margin="610,197,0,0" Width="300" IsEditable="True" IsReadOnly="True" SelectionChanged="SpellMask_SelectionChanged"/>
                                         <Label Content="{DynamicResource labSpellClassMask3}" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="471,228,0,0"/>
-                                        <c:ThreadSafeComboBox x:Name="SpellMask32" VerticalAlignment="Top" HorizontalAlignment="Left" Height="23" Margin="610,228,0,0" Width="300" IsEditable="True" IsReadOnly="True" />
+                                        <c:ThreadSafeComboBox x:Name="SpellMask32" VerticalAlignment="Top" HorizontalAlignment="Left" Height="23" Margin="610,228,0,0" Width="300" IsEditable="True" IsReadOnly="True" SelectionChanged="SpellMask_SelectionChanged"/>
                                         <Label Content="{DynamicResource labDamageMultiplier2}" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="471,259,0,0"/>
                                         <c:ThreadSafeTextBox x:Name="EffectDamageMultiplier2" VerticalAlignment="Top" HorizontalAlignment="Left" Height="23" Margin="610,259,0,0" Width="300" TextWrapping="Wrap"/>
                                         <Label Content="{DynamicResource labEffectBonusMultiplier2}" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="471,290,0,0"/>
                                         <c:ThreadSafeTextBox x:Name="EffectBonusMultiplier2" VerticalAlignment="Top" HorizontalAlignment="Left" Height="23" Margin="610,290,0,0" Width="300" TextWrapping="Wrap"/>
+                                        <Label Content="{DynamicResource targetClassMaskSpells}" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="929,42,0,0" RenderTransformOrigin="0.6,3.9"/>
+                                        <ListBox x:Name="EffectTargetSpellsList2" VerticalAlignment="Top" HorizontalAlignment="Left" Height="469" Margin="929,73,0,0" Width="300" BorderThickness="1"/>
                                     </Grid>
                                 </TabItem>
                                 <TabItem Header="{DynamicResource SpellEffects3}">
@@ -619,15 +623,17 @@
                                         <Label Content="{DynamicResource labMiscValueB}" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="471,135,0,0"/>
                                         <c:ThreadSafeTextBox x:Name="MiscValueB3" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="610,135,0,0" Width="300" TextWrapping="Wrap"/>
                                         <Label Content="{DynamicResource labSpellClassMask1}" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="471,166,0,0"/>
-                                        <c:ThreadSafeComboBox x:Name="SpellMask13" VerticalAlignment="Top" HorizontalAlignment="Left" Height="23" Margin="610,166,0,0" Width="300" IsEditable="True" IsReadOnly="True" />
+                                        <c:ThreadSafeComboBox x:Name="SpellMask13" VerticalAlignment="Top" HorizontalAlignment="Left" Height="23" Margin="610,166,0,0" Width="300" IsEditable="True" IsReadOnly="True" SelectionChanged="SpellMask_SelectionChanged"/>
                                         <Label Content="{DynamicResource labSpellClassMask2}" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="471,197,0,0"/>
-                                        <c:ThreadSafeComboBox x:Name="SpellMask23" VerticalAlignment="Top" HorizontalAlignment="Left" Height="23" Margin="610,197,0,0" Width="300" IsEditable="True" IsReadOnly="True" />
+                                        <c:ThreadSafeComboBox x:Name="SpellMask23" VerticalAlignment="Top" HorizontalAlignment="Left" Height="23" Margin="610,197,0,0" Width="300" IsEditable="True" IsReadOnly="True" SelectionChanged="SpellMask_SelectionChanged"/>
                                         <Label Content="{DynamicResource labSpellClassMask3}" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="471,228,0,0"/>
-                                        <c:ThreadSafeComboBox x:Name="SpellMask33" VerticalAlignment="Top" HorizontalAlignment="Left" Height="23" Margin="610,228,0,0" Width="300" IsEditable="True" IsReadOnly="True" />
+                                        <c:ThreadSafeComboBox x:Name="SpellMask33" VerticalAlignment="Top" HorizontalAlignment="Left" Height="23" Margin="610,228,0,0" Width="300" IsEditable="True" IsReadOnly="True" SelectionChanged="SpellMask_SelectionChanged"/>
                                         <Label Content="{DynamicResource labDamageMultiplier2}" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="471,259,0,0"/>
                                         <c:ThreadSafeTextBox x:Name="EffectDamageMultiplier3" VerticalAlignment="Top" HorizontalAlignment="Left" Height="23" Margin="610,259,0,0" Width="300" TextWrapping="Wrap"/>
                                         <Label Content="{DynamicResource labEffectBonusMultiplier2}" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="471,290,0,0"/>
                                         <c:ThreadSafeTextBox x:Name="EffectBonusMultiplier3" VerticalAlignment="Top" HorizontalAlignment="Left" Height="23" Margin="610,290,0,0" Width="300" TextWrapping="Wrap"/>
+                                        <Label Content="{DynamicResource targetClassMaskSpells}" VerticalAlignment="Top" HorizontalAlignment="Left" Margin="929,42,0,0" RenderTransformOrigin="0.6,3.9"/>
+                                        <ListBox x:Name="EffectTargetSpellsList3" VerticalAlignment="Top" HorizontalAlignment="Left" Height="469" Margin="929,73,0,0" Width="300" BorderThickness="1"/>
                                     </Grid>
                                 </TabItem>
                             </TabControl>

--- a/SpellGUIV2/MainWindow.xaml.cs
+++ b/SpellGUIV2/MainWindow.xaml.cs
@@ -2718,16 +2718,6 @@ namespace SpellEditor
                     SpellFamilyFlags1.ThreadSafeText = row["SpellFamilyFlags1"].ToString();
                     SpellFamilyFlags2.ThreadSafeText = row["SpellFamilyFlags2"].ToString();
 
-                    UpdateSpellMaskCheckBox(uint.Parse(row["EffectSpellClassMaskA1"].ToString()), SpellMask11);
-                    UpdateSpellMaskCheckBox(uint.Parse(row["EffectSpellClassMaskA2"].ToString()), SpellMask21);
-                    UpdateSpellMaskCheckBox(uint.Parse(row["EffectSpellClassMaskA3"].ToString()), SpellMask31);
-                    UpdateSpellMaskCheckBox(uint.Parse(row["EffectSpellClassMaskB1"].ToString()), SpellMask12);
-                    UpdateSpellMaskCheckBox(uint.Parse(row["EffectSpellClassMaskB2"].ToString()), SpellMask22);
-                    UpdateSpellMaskCheckBox(uint.Parse(row["EffectSpellClassMaskB3"].ToString()), SpellMask32);
-                    UpdateSpellMaskCheckBox(uint.Parse(row["EffectSpellClassMaskC1"].ToString()), SpellMask13);
-                    UpdateSpellMaskCheckBox(uint.Parse(row["EffectSpellClassMaskC2"].ToString()), SpellMask23);
-                    UpdateSpellMaskCheckBox(uint.Parse(row["EffectSpellClassMaskC3"].ToString()), SpellMask33);
-
                     var masks = new List<uint>
                     {
                         uint.Parse(row["EffectSpellClassMaskA1"].ToString()),
@@ -2740,6 +2730,16 @@ namespace SpellEditor
                         uint.Parse(row["EffectSpellClassMaskC2"].ToString()),
                         uint.Parse(row["EffectSpellClassMaskC3"].ToString())
                     };
+
+                    UpdateSpellMaskCheckBox(masks[0], SpellMask11);
+                    UpdateSpellMaskCheckBox(masks[1], SpellMask21);
+                    UpdateSpellMaskCheckBox(masks[2], SpellMask31);
+                    UpdateSpellMaskCheckBox(masks[3], SpellMask12);
+                    UpdateSpellMaskCheckBox(masks[4], SpellMask22);
+                    UpdateSpellMaskCheckBox(masks[5], SpellMask32);
+                    UpdateSpellMaskCheckBox(masks[6], SpellMask13);
+                    UpdateSpellMaskCheckBox(masks[7], SpellMask23);
+                    UpdateSpellMaskCheckBox(masks[8], SpellMask33);
 
                     Dispatcher.BeginInvoke(DispatcherPriority.Background, new Action(() => 
                         spellFamilyClassMaskParser.UpdateSpellFamilyClassMask(this, familyName, isWotlkOrGreater, GetDBAdapter(), masks)));

--- a/SpellGUIV2/MainWindow.xaml.cs
+++ b/SpellGUIV2/MainWindow.xaml.cs
@@ -2839,6 +2839,10 @@ namespace SpellEditor
                 SpellMissileID.IsEnabled = isWotlkOrGreater;
                 SpellDescriptionVariables.IsEnabled = isWotlkOrGreater;
                 Difficulty.IsEnabled = isWotlkOrGreater;
+
+                FilterClassMaskSpells1.IsEnabled = isWotlkOrGreater;
+                FilterClassMaskSpells2.IsEnabled = isWotlkOrGreater;
+                FilterClassMaskSpells3.IsEnabled = isWotlkOrGreater;
             }
             catch (Exception e)
             {

--- a/SpellGUIV2/MainWindow.xaml.cs
+++ b/SpellGUIV2/MainWindow.xaml.cs
@@ -643,6 +643,8 @@ namespace SpellEditor
                 Mask += cb.IsChecked == true ? (uint)Math.Pow(2, i) : 0;
             }
             father.Text = Mask.ToString();
+
+            SpellMask_SelectionChanged(father, null);
         }
 
         #endregion
@@ -2699,7 +2701,7 @@ namespace SpellEditor
                     SpellFamilyFlags1.ThreadSafeText = row["SpellFamilyFlags2"].ToString();
 
                     Dispatcher.BeginInvoke(DispatcherPriority.Background, new Action(() => 
-                        spellFamilyClassMaskParser?.UpdateSpellFamilyClassMask(this, familyName, isWotlkOrGreater)));
+                        spellFamilyClassMaskParser?.UpdateSpellFamilyClassMask(this, familyName, isWotlkOrGreater, adapter, null)));
                 }
                 else
                 {
@@ -2729,8 +2731,21 @@ namespace SpellEditor
                     UpdateSpellMaskCheckBox(uint.Parse(row["EffectSpellClassMaskC2"].ToString()), SpellMask23);
                     UpdateSpellMaskCheckBox(uint.Parse(row["EffectSpellClassMaskC3"].ToString()), SpellMask33);
 
+                    var masks = new List<uint>
+                    {
+                        uint.Parse(row["EffectSpellClassMaskA1"].ToString()),
+                        uint.Parse(row["EffectSpellClassMaskA2"].ToString()),
+                        uint.Parse(row["EffectSpellClassMaskA3"].ToString()),
+                        uint.Parse(row["EffectSpellClassMaskB1"].ToString()),
+                        uint.Parse(row["EffectSpellClassMaskB2"].ToString()),
+                        uint.Parse(row["EffectSpellClassMaskB3"].ToString()),
+                        uint.Parse(row["EffectSpellClassMaskC1"].ToString()),
+                        uint.Parse(row["EffectSpellClassMaskC2"].ToString()),
+                        uint.Parse(row["EffectSpellClassMaskC3"].ToString())
+                    };
+
                     Dispatcher.BeginInvoke(DispatcherPriority.Background, new Action(() => 
-                        spellFamilyClassMaskParser.UpdateSpellFamilyClassMask(this, familyName, isWotlkOrGreater)));
+                        spellFamilyClassMaskParser.UpdateSpellFamilyClassMask(this, familyName, isWotlkOrGreater, GetDBAdapter(), masks)));
                 }
                 SpellFamilyFlags2.IsEnabled = isWotlkOrGreater;
                 ToggleAllSpellMaskCheckBoxes(isWotlkOrGreater);
@@ -4019,6 +4034,28 @@ namespace SpellEditor
                 }
                 return false;
             };
+        }
+
+        private void SpellMask_SelectionChanged(object sender, SelectionChangedEventArgs e)
+        {
+            if (!WoWVersionManager.IsWotlkOrGreaterSelected)
+                return;
+
+            var masks = new List<uint>
+            {
+                uint.Parse(SpellMask11.Text),
+                uint.Parse(SpellMask21.Text),
+                uint.Parse(SpellMask31.Text),
+                uint.Parse(SpellMask21.Text),
+                uint.Parse(SpellMask22.Text),
+                uint.Parse(SpellMask23.Text),
+                uint.Parse(SpellMask31.Text),
+                uint.Parse(SpellMask32.Text),
+                uint.Parse(SpellMask33.Text)
+            };
+
+            Dispatcher.BeginInvoke(DispatcherPriority.Background, new Action(() =>
+                spellFamilyClassMaskParser.UpdateSpellEffectMasksSelected(this, uint.Parse(SpellFamilyName.Text), GetDBAdapter(), masks)));
         }
 
         private string SafeTryFindResource(object key)

--- a/SpellGUIV2/MainWindow.xaml.cs
+++ b/SpellGUIV2/MainWindow.xaml.cs
@@ -1036,10 +1036,7 @@ namespace SpellEditor
                         {
                             if (!(enumerator.Current is TextBlock block))
                                 continue;
-
-                            var name = block.Text;
-                            var spellName = name.Substring(name.IndexOf(' ', 4) + 1);
-                            return spellName.ToLower().Contains(input);
+                            return input.Length == 0 ? true : block.Text.ToLower().Contains(input);
                         }
                     }
                     return false;
@@ -4056,6 +4053,26 @@ namespace SpellEditor
 
             Dispatcher.BeginInvoke(DispatcherPriority.Background, new Action(() =>
                 spellFamilyClassMaskParser.UpdateSpellEffectMasksSelected(this, uint.Parse(SpellFamilyName.Text), GetDBAdapter(), masks)));
+        }
+
+        private void FilterClassMaskSpells_TextChanged(object sender, TextChangedEventArgs e)
+        {
+            ListBox targetBox;
+            if (sender == FilterClassMaskSpells1)
+                targetBox = EffectTargetSpellsList1;
+            else if (sender == FilterClassMaskSpells2)
+                targetBox = EffectTargetSpellsList2;
+            else if (sender == FilterClassMaskSpells3)
+                targetBox = EffectTargetSpellsList3;
+            else
+            {
+                Logger.Error($"Unable to find target box to Class Mask Filter: {sender}");
+                return;
+            }
+            var filterBox = sender as ThreadSafeTextBox;
+            var input = filterBox.Text.ToLower();
+            ICollectionView view = CollectionViewSource.GetDefaultView(targetBox.Items);
+            view.Filter = o => input.Length == 0 ? true : o.ToString().ToLower().Contains(input);
         }
 
         private string SafeTryFindResource(object key)

--- a/SpellGUIV2/Sources/Database/MySQL.cs
+++ b/SpellGUIV2/Sources/Database/MySQL.cs
@@ -35,10 +35,10 @@ namespace SpellEditor.Sources.Database
 
         ~MySQL()
         {
-            if (_connection != null && _connection.State != ConnectionState.Closed)
-                _connection.Close();
             _heartbeat?.Dispose();
             _heartbeat = null;
+            if (_connection != null && _connection.State != ConnectionState.Closed)
+                _connection.Close();
         }
 
         public void CreateAllTablesFromBindings()


### PR DESCRIPTION
The target spells for an effect are determined based on a bitwise AND of the effect class masks with the spell family flags. The spell family name must be an exact match as well.

![image](https://i.imgur.com/ujz1TkF.png)