### PR TITLE
Lazy initialization so configuration can be loaded

### DIFF
--- a/SpellGUIV2/Sources/Binding/BindingManager.cs
+++ b/SpellGUIV2/Sources/Binding/BindingManager.cs
@@ -11,7 +11,9 @@ namespace SpellEditor.Sources.Binding
     {
         private static readonly Logger Logger = LogManager.GetCurrentClassLogger();
 
-        private static BindingManager _instance = new BindingManager();
+        private static volatile BindingManager _instance;
+        private static readonly object _lock = new object();
+
         private List<Binding> _bindings;
         
         private BindingManager()
@@ -53,6 +55,15 @@ namespace SpellEditor.Sources.Binding
 
         public static BindingManager GetInstance()
         {
+            if (_instance != null)
+                return _instance;
+
+            lock (_lock)
+            {
+                if (_instance == null)
+                    _instance = new BindingManager();
+            }
+
             return _instance;
         }
 


### PR DESCRIPTION
The headless exporter previously couldn't find any bindings because the
configuration wouldn't be loaded and the bindings directory would be the
default value. Turning the binding manager from eager initialization to
lazy initialization seems to have fixed this and seems to have not
affected the GUI.